### PR TITLE
Improved element acquisition!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.umutayb</groupId>
   <artifactId>Pickleib</artifactId>
-  <version>1.7.9</version>
+  <version>1.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Pickleib</name>
@@ -45,7 +45,7 @@
     <java.utilities.version>1.4.6</java.utilities.version>
     <gpt.utilities.version>0.1.3</gpt.utilities.version>
     <docker-java.version>3.3.0</docker-java.version>
-    <selenium.version>4.8.3</selenium.version>
+    <selenium.version>4.11.0</selenium.version>
     <appium.version>8.5.1</appium.version>
     <retrofit.version>2.9.0</retrofit.version>
     <okhttp.version>4.10.0</okhttp.version>

--- a/src/main/java/pickleib/utilities/page/repository/PageRepository.java
+++ b/src/main/java/pickleib/utilities/page/repository/PageRepository.java
@@ -1,0 +1,8 @@
+package pickleib.utilities.page.repository;
+
+/**
+ * Page repositories are objects containing instances of all page objects in a given project.
+ */
+public interface PageRepository {
+
+}


### PR DESCRIPTION
Element acquisition methods do not require an instance of a page repository anymore, instead, the page repository class is passed from the constructor of ElementAcquisition subclasses